### PR TITLE
Pass extra session info to subscription callbacks that requested so

### DIFF
--- a/cffi/cdefs.h
+++ b/cffi/cdefs.h
@@ -85,6 +85,8 @@ int sr_session_stop(sr_session_ctx_t *);
 int sr_session_switch_ds(sr_session_ctx_t *, sr_datastore_t);
 sr_datastore_t sr_session_get_ds(sr_session_ctx_t *);
 sr_conn_ctx_t *sr_session_get_connection(sr_session_ctx_t *);
+uint32_t sr_session_get_event_nc_id(sr_session_ctx_t *);
+const char *sr_session_get_event_user(sr_session_ctx_t *);
 int sr_get_error(sr_session_ctx_t *, const sr_error_info_t **);
 int sr_set_error(sr_session_ctx_t *, const char *, const char *, ...);
 

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -125,3 +125,11 @@ class SessionTest(unittest.TestCase):
                     }
                 },
             )
+
+    def test_get_netconf_id_and_get_user_are_only_available_in_implicit_session(self):
+        with self.conn.start_session("running") as sess:
+            with self.assertRaises(sysrepo.SysrepoUnsupportedError):
+                sess.get_netconf_id()
+
+            with self.assertRaises(sysrepo.SysrepoUnsupportedError):
+                sess.get_user()

--- a/tests/test_subs_notification.py
+++ b/tests/test_subs_notification.py
@@ -1,6 +1,7 @@
 # Copyright (c) 2020 6WIND S.A.
 # SPDX-License-Identifier: BSD-3-Clause
 
+import getpass
 import logging
 import os
 import threading
@@ -32,30 +33,49 @@ class NotificationSubscriptionTest(unittest.TestCase):
         with sysrepo.SysrepoConnection(err_on_sched_fail=True):
             pass
 
-    def _test_notification_sub(self, notif_xpath: str, notif_dict: typing.Dict):
+    def _test_notification_sub(
+        self,
+        notif_xpath: str,
+        notif_dict: typing.Dict,
+        request_extra_info: bool = False,
+    ):
         priv = object()
         callback_called = threading.Event()
 
-        def notif_cb(xpath, notification_type, notification, timestamp, private_data):
+        def notif_cb(
+            xpath, notification_type, notification, timestamp, private_data, **kwargs
+        ):
             self.assertEqual(xpath, notif_xpath)
             self.assertEqual(notification_type, "realtime")
             self.assertEqual(notification, notif_dict)
             self.assertIsInstance(timestamp, int)
             self.assertAlmostEqual(timestamp, int(time.time()), delta=5)
             self.assertEqual(private_data, priv)
+            if request_extra_info:
+                self.assertIn("user", kwargs)
+                self.assertEqual(getpass.getuser(), kwargs["user"])
+                self.assertIn("netconf_id", kwargs)
+                self.assertIsInstance(kwargs["netconf_id"], int)
+            else:
+                self.assertEqual(0, len(kwargs))
 
             callback_called.set()
 
-        with self.conn.start_session() as sess:
-            sess.subscribe_notification(
-                "sysrepo-example", notif_xpath, notif_cb, private_data=priv
+        with self.conn.start_session() as listening_session:
+            if request_extra_info:
+                kwargs = {"extra_info": True}
+            else:
+                kwargs = {}
+            listening_session.subscribe_notification(
+                "sysrepo-example", notif_xpath, notif_cb, private_data=priv, **kwargs
             )
 
-            sess.notification_send(notif_xpath, notif_dict)
-            self.assertTrue(
-                callback_called.wait(timeout=1),
-                "Timed-out while waiting for the notification callback to be called",
-            )
+            with self.conn.start_session() as sending_session:
+                sending_session.notification_send(notif_xpath, notif_dict)
+                self.assertTrue(
+                    callback_called.wait(timeout=1),
+                    "Timed-out while waiting for the notification callback to be called",
+                )
 
     def test_notification_top_level(self):
         self._test_notification_sub(
@@ -67,4 +87,11 @@ class NotificationSubscriptionTest(unittest.TestCase):
         self._test_notification_sub(
             notif_xpath="/sysrepo-example:state/state-changed",
             notif_dict={"message": "Some state changed"},
+        )
+
+    def test_notification_sub_with_extra_info(self):
+        self._test_notification_sub(
+            notif_xpath="/sysrepo-example:state/state-changed",
+            notif_dict={"message": "Some state changed"},
+            request_extra_info=True,
         )


### PR DESCRIPTION
* For some niche use cases, during the execution of a subscription callback,
  it is useful to have access to certain session information (e.g., username
  and NETCONF session ID that triggered the callback, etc.)

* Add "extra_info" argument to all "SysrepoSession.subscribe_xxx" methods
  (with a default value of False) to indicate the desire to receive extra
  keyword arguments during the callback call

* Pass "netconf_id" (int) and "user" (str) keyword arguments to all callbacks
  which were subscribed with "extra_info=True"

* Extend unit tests to include and cover this new feature