### PR TITLE
libyang2: Make sysrepo-python works with libyang2

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ lint:
 	tox -e lint
 
 tests:
-	tox -e py3-libyang1
+	tox -e py37
 
 format:
 	tox -e format

--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ lint:
 	tox -e lint
 
 tests:
-	tox -e py37
+	tox -e py3
 
 format:
 	tox -e format

--- a/cffi/cdefs.h
+++ b/cffi/cdefs.h
@@ -45,6 +45,7 @@ typedef struct sr_conn_ctx_s sr_conn_ctx_t;
 typedef struct sr_session_ctx_s sr_session_ctx_t;
 typedef enum sr_conn_flag_e {
 	SR_CONN_CACHE_RUNNING,
+	SR_CONN_CTX_SET_PRIV_PARSED,
 	...
 } sr_conn_flag_t;
 typedef uint32_t sr_conn_options_t;

--- a/cffi/cdefs.h
+++ b/cffi/cdefs.h
@@ -74,6 +74,7 @@ struct timespec;
 int sr_connect(const sr_conn_options_t, sr_conn_ctx_t **);
 int sr_disconnect(sr_conn_ctx_t *);
 const struct ly_ctx *sr_acquire_context(sr_conn_ctx_t *);
+void sr_release_context(sr_conn_ctx_t *);
 int sr_install_module(sr_conn_ctx_t *, const char *, const char *, const char **);
 int sr_remove_module(sr_conn_ctx_t *, const char *, int);
 int sr_update_module(sr_conn_ctx_t *, const char *, const char *);
@@ -173,6 +174,7 @@ int sr_get_items(sr_session_ctx_t *, const char *, uint32_t,
 	const sr_get_oper_options_t, sr_val_t **, size_t *);
 int sr_get_data(sr_session_ctx_t *, const char *, uint32_t, uint32_t,
 	const sr_get_oper_options_t, sr_data_t **);
+void sr_release_data(sr_data_t *);
 int sr_rpc_send_tree(sr_session_ctx_t *, struct lyd_node *, uint32_t, sr_data_t **);
 
 int sr_set_item_str(sr_session_ctx_t *, const char *, const char *, const char *, const sr_edit_options_t);

--- a/cffi/cdefs.h
+++ b/cffi/cdefs.h
@@ -69,7 +69,11 @@ typedef struct sr_error_info_s {
 /* forward declarations from libyang */
 struct ly_ctx;
 struct lyd_node;
-struct timespec;
+typedef int... time_t;
+struct timespec {
+    time_t tv_sec;
+    long tv_nsec;
+};
 
 int sr_connect(const sr_conn_options_t, sr_conn_ctx_t **);
 int sr_disconnect(sr_conn_ctx_t *);
@@ -201,7 +205,6 @@ typedef struct sr_subscription_ctx_s sr_subscription_ctx_t;
 typedef uint32_t sr_subscr_options_t;
 
 int sr_get_event_pipe(sr_subscription_ctx_t *, int *);
-typedef int... time_t;
 int sr_subscription_process_events(sr_subscription_ctx_t *, sr_session_ctx_t *, struct timespec *);
 int sr_unsubscribe(sr_subscription_ctx_t *);
 
@@ -269,7 +272,7 @@ typedef enum sr_ev_notif_type_e {
 
 extern "Python" void srpy_event_notif_tree_cb(
 	sr_session_ctx_t *, uint32_t sub_id, const sr_ev_notif_type_t notif_type, const struct lyd_node *notif,
-	time_t timestamp, void *priv);
+	struct timespec* timestamp, void *priv);
 
 int sr_notif_subscribe_tree(sr_session_ctx_t *, const char *module_name, const char *xpath, struct timespec *start_time, struct timespec *stop_time,
 	void (*)(sr_session_ctx_t *, uint32_t, const sr_ev_notif_type_t, const struct lyd_node*, struct timespec*, void*),

--- a/cffi/cdefs.h
+++ b/cffi/cdefs.h
@@ -63,7 +63,7 @@ typedef struct sr_error_info_err_s {
 } sr_error_info_err_t;
 typedef struct sr_error_info_s {
 	sr_error_info_err_t *err;
-	size_t err_count;
+	uint32_t err_count;
 } sr_error_info_t;
 
 /* forward declarations from libyang */
@@ -119,7 +119,7 @@ typedef enum sr_val_type_e {
 typedef union sr_val_data_u {
 	char *binary_val;
 	char *bits_val;
-	bool bool_val;
+	int bool_val;
 	double decimal64_val;
 	char *enum_val;
 	char *identityref_val;

--- a/cffi/cdefs.h
+++ b/cffi/cdefs.h
@@ -89,7 +89,9 @@ sr_conn_ctx_t *sr_session_get_connection(sr_session_ctx_t *);
 int sr_session_get_error(sr_session_ctx_t *, const sr_error_info_t **);
 int sr_session_set_error_message(sr_session_ctx_t *, const char *, ...);
 const char *sr_session_get_orig_name(sr_session_ctx_t *session);
+int sr_session_set_orig_name(sr_session_ctx_t *session, const char *);
 int sr_session_get_orig_data(sr_session_ctx_t *session, uint32_t idx, uint32_t *size, const void **data);
+int sr_session_push_orig_data(sr_session_ctx_t * session, uint32_t size, const void *data);
 
 typedef enum sr_val_type_e {
 	SR_UNKNOWN_T,

--- a/examples/sysrepocfg.py
+++ b/examples/sysrepocfg.py
@@ -96,8 +96,8 @@ def main():
                     data = ctx.parse_data_mem(
                         sys.stdin.read(),
                         args.format,
-                        config=True,
-                        strict=not args.not_strict,
+                        parser_no_state=True,
+                        parser_strict=not args.not_strict,
                     )
                     sess.replace_config_ly(data, args.import_)
 
@@ -114,7 +114,7 @@ def main():
                     rpc_input = ctx.parse_data_mem(
                         sys.stdin.read(),
                         args.format,
-                        strict=not args.not_strict,
+                        parser_strict=not args.not_strict,
                     )
                     try:
                         rpc_output = sess.rpc_send_ly(rpc_input)

--- a/examples/sysrepocfg.py
+++ b/examples/sysrepocfg.py
@@ -90,40 +90,37 @@ def main():
 
     try:
         with sysrepo.SysrepoConnection() as conn:
-            ctx = conn.get_ly_ctx()
             with conn.start_session(args.datastore) as sess:
                 if args.import_:
-                    data = ctx.parse_data_mem(
-                        sys.stdin.read(),
-                        args.format,
-                        parser_no_state=True,
-                        parser_strict=not args.not_strict,
-                    )
-                    sess.replace_config_ly(data, args.import_)
+                    with conn.get_ly_ctx() as ctx:
+                        data = ctx.parse_data_mem(
+                            sys.stdin.read(),
+                            args.format,
+                            parser_no_state=True,
+                            parser_strict=not args.not_strict,
+                        )
+                        sess.replace_config_ly(data, args.import_)
 
                 elif args.export:
-                    data = sess.get_data_ly(args.export)
-                    try:
+                    with sess.get_data_ly(args.export) as data:
                         data.print_file(
                             sys.stdout, args.format, pretty=True, with_siblings=True
                         )
-                    finally:
-                        data.free()
 
                 elif args.rpc:
-                    rpc_input = ctx.parse_data_mem(
-                        sys.stdin.read(),
-                        args.format,
-                        parser_strict=not args.not_strict,
-                    )
-                    try:
-                        rpc_output = sess.rpc_send_ly(rpc_input)
-                    finally:
-                        rpc_input.free()
-                    try:
-                        rpc_output.print_file(sys.stdout, args.format, pretty=True)
-                    finally:
-                        rpc_output.free()
+                    with conn.get_ly_ctx() as ctx:
+                        rpc_input = ctx.parse_data_mem(
+                            sys.stdin.read(),
+                            args.format,
+                            parser_strict=not args.not_strict,
+                        )
+                        with sess.rpc_send_ly(rpc_input) as rpc_output:
+                            try:
+                                rpc_output.print_file(
+                                    sys.stdout, args.format, pretty=True
+                                )
+                            finally:
+                                rpc_input.free()
 
         return 0
     except sysrepo.SysrepoError as e:

--- a/examples/sysrepocfg.py
+++ b/examples/sysrepocfg.py
@@ -114,7 +114,6 @@ def main():
                     rpc_input = ctx.parse_data_mem(
                         sys.stdin.read(),
                         args.format,
-                        rpc=True,
                         strict=not args.not_strict,
                     )
                     try:

--- a/setup.py
+++ b/setup.py
@@ -154,7 +154,7 @@ setuptools.setup(
         'cffi; platform_python_implementation != "PyPy"',
     ],
     install_requires=[
-        "libyang>2",
+        "libyang>=2",
         'cffi; platform_python_implementation != "PyPy"',
     ],
     cffi_modules=["cffi/build.py:BUILDER"],

--- a/setup.py
+++ b/setup.py
@@ -154,7 +154,7 @@ setuptools.setup(
         'cffi; platform_python_implementation != "PyPy"',
     ],
     install_requires=[
-        "libyang>=1.7.0,<2",
+        "libyang>2",
         'cffi; platform_python_implementation != "PyPy"',
     ],
     cffi_modules=["cffi/build.py:BUILDER"],

--- a/sysrepo/change.py
+++ b/sysrepo/change.py
@@ -109,7 +109,7 @@ class Change:
 # ------------------------------------------------------------------------------
 class ChangeCreated(Change):
 
-    __slots__ = Change.__slots__ + ("value", "after")
+    __slots__ = ("value", "after")
 
     def __init__(self, xpath: str, value: Any, after: Optional[str] = None):
         super().__init__(xpath)
@@ -134,7 +134,7 @@ class ChangeCreated(Change):
 # ------------------------------------------------------------------------------
 class ChangeModified(Change):
 
-    __slots__ = Change.__slots__ + ("value", "prev_val", "prev_dflt")
+    __slots__ = ("value", "prev_val", "prev_dflt")
 
     def __init__(self, xpath: str, value: Any, prev_val: str, prev_dflt: bool = False):
         super().__init__(xpath)
@@ -162,7 +162,7 @@ class ChangeDeleted(Change):
 # ------------------------------------------------------------------------------
 class ChangeMoved(Change):
 
-    __slots__ = Change.__slots__ + ("after",)
+    __slots__ = ("after",)
 
     def __init__(self, xpath: str, after: str):
         super().__init__(xpath)

--- a/sysrepo/connection.py
+++ b/sysrepo/connection.py
@@ -44,6 +44,10 @@ class SysrepoConnection:
         flags = 0
         if cache_running:
             flags |= lib.SR_CONN_CACHE_RUNNING
+
+        # mandatory flag to work with libyang-python
+        flags |= lib.SR_CONN_CTX_SET_PRIV_PARSED
+
         conn_p = ffi.new("sr_conn_ctx_t **")
         # valid_signals() is only available since python 3.8
         valid_signals = getattr(signal, "valid_signals", lambda: range(1, signal.NSIG))

--- a/sysrepo/connection.py
+++ b/sysrepo/connection.py
@@ -119,7 +119,7 @@ class SysrepoConnection:
         :returns:
             The `libyang.Context` object associated with this connection.
         """
-        ctx = lib.sr_get_context(self.cdata)
+        ctx = lib.sr_acquire_context(self.cdata)
         if not ctx:
             raise SysrepoInternalError("sr_get_context failed")
         return libyang.Context(cdata=ctx)
@@ -155,7 +155,7 @@ class SysrepoConnection:
             features
         )
 
-    def remove_module(self, name: str) -> None:
+    def remove_module(self, name: str, force: bool = False) -> None:
         """
         Remove an installed module from sysrepo. Deferred until there are no
         connections!
@@ -163,4 +163,4 @@ class SysrepoConnection:
         :arg str name:
             Name of the module to remove.
         """
-        check_call(lib.sr_remove_module, self.cdata, str2c(name))
+        check_call(lib.sr_remove_module, self.cdata, str2c(name), force)

--- a/sysrepo/connection.py
+++ b/sysrepo/connection.py
@@ -35,31 +35,15 @@ class SysrepoConnection:
 
     __slots__ = ("cdata",)
 
-    def __init__(
-        self,
-        cache_running: bool = False,
-        no_sched_changes: bool = False,
-        err_on_sched_fail: bool = False,
-    ):
+    def __init__(self, cache_running: bool = False):
         """
         :arg cache_running:
             Always cache running datastore data which makes mainly repeated retrieval of
             data much faster. Affects all sessions created on this connection.
-        :arg no_sched_changes:
-            Do not parse internal modules data and apply any scheduled changes. Makes
-            creating the connection faster but, obviously, scheduled changes are not
-            applied.
-        :arg err_on_sched_fail:
-            If applying any of the scheduled changes fails, do not create a connection
-            and return an error.
         """
         flags = 0
         if cache_running:
             flags |= lib.SR_CONN_CACHE_RUNNING
-        if no_sched_changes:
-            flags |= lib.SR_CONN_NO_SCHED_CHANGES
-        if err_on_sched_fail:
-            flags |= lib.SR_CONN_ERR_ON_SCHED_FAIL
         conn_p = ffi.new("sr_conn_ctx_t **")
         # valid_signals() is only available since python 3.8
         valid_signals = getattr(signal, "valid_signals", lambda: range(1, signal.NSIG))

--- a/sysrepo/connection.py
+++ b/sysrepo/connection.py
@@ -144,7 +144,7 @@ class SysrepoConnection:
         """
         if enabled_features:
             # convert to C strings array
-            features = tuple(str2c(f) for f in enabled_features)
+            features = tuple([str2c(f) for f in enabled_features] + [ffi.NULL])
         else:
             features = ffi.NULL
         check_call(
@@ -152,8 +152,7 @@ class SysrepoConnection:
             self.cdata,
             str2c(filepath),
             str2c(searchdirs),
-            features,
-            len(enabled_features),
+            features
         )
 
     def remove_module(self, name: str) -> None:

--- a/sysrepo/connection.py
+++ b/sysrepo/connection.py
@@ -136,7 +136,7 @@ class SysrepoConnection:
             self.cdata,
             str2c(filepath),
             str2c(searchdirs),
-            features
+            features,
         )
 
     def remove_module(self, name: str, force: bool = False) -> None:

--- a/sysrepo/connection.py
+++ b/sysrepo/connection.py
@@ -117,7 +117,7 @@ class SysrepoConnection:
         filepath: str,
         searchdirs: Optional[str] = None,
         enabled_features: Sequence[str] = (),
-        ignore_already_exists = True,
+        ignore_already_exists=True,
     ) -> None:
         """
         Install a new schema (module) into sysrepo.
@@ -141,14 +141,14 @@ class SysrepoConnection:
         if ignore_already_exists:
             valid_codes = (lib.SR_ERR_OK, lib.SR_ERR_EXISTS)
         else:
-            valid_codes = (lib.SR_ERR_OK, )
+            valid_codes = (lib.SR_ERR_OK,)
         check_call(
             lib.sr_install_module,
             self.cdata,
             str2c(filepath),
             str2c(searchdirs),
             features,
-            valid_codes=valid_codes
+            valid_codes=valid_codes,
         )
 
     def remove_module(self, name: str, force: bool = False) -> None:

--- a/sysrepo/errors.py
+++ b/sysrepo/errors.py
@@ -44,7 +44,7 @@ class SysrepoInvalArgError(SysrepoError):
 
 @SysrepoError.register
 class SysrepoNomemError(SysrepoError):
-    rc = lib.SR_ERR_NOMEM
+    rc = lib.SR_ERR_NO_MEMORY
 
 
 @SysrepoError.register
@@ -122,7 +122,7 @@ def _get_error_msg(session) -> Optional[str]:
     """
     msg = None
     err_info_p = ffi.new("sr_error_info_t **")
-    if lib.sr_get_error(session, err_info_p) == lib.SR_ERR_OK:
+    if lib.sr_session_get_error(session, err_info_p) == lib.SR_ERR_OK:
         err_info = err_info_p[0]
         error_strings = []
         if err_info != ffi.NULL:
@@ -162,7 +162,7 @@ def check_call(
     :raises SysrepoError:
         If the function returned an error code not listed in valid_codes. If
         the first argument in args is a sr_session_ctx_t object, use it to call
-        sr_get_error() to get a detailed error message for the risen exception.
+        sr_session_get_error() to get a detailed error message for the risen exception.
     """
     ret = func(*args)
     if ret not in valid_codes:

--- a/sysrepo/errors.py
+++ b/sysrepo/errors.py
@@ -129,8 +129,6 @@ def _get_error_msg(session) -> Optional[str]:
             for i in range(err_info.err_count):
                 err = err_info.err[i]
                 strings = []
-                if err.xpath:
-                    strings.append(c2str(err.xpath))
                 if err.message:
                     strings.append(c2str(err.message))
                 if strings:

--- a/sysrepo/session.py
+++ b/sysrepo/session.py
@@ -693,13 +693,18 @@ class SysrepoSession:
 
         flags = _subscribe_flags(no_thread=no_thread)
 
+        c_start_time = ffi.new("struct timespec *")
+        c_start_time.tv_sec = start_time
+        c_stop_time = ffi.new("struct timespec *")
+        c_stop_time.tv_sec = stop_time
+
         check_call(
-            lib.sr_event_notif_subscribe_tree,
+            lib.sr_notif_subscribe_tree,
             self.cdata,
             str2c(module),
             str2c(xpath),
-            start_time,
-            stop_time,
+            c_start_time,
+            c_stop_time,
             lib.srpy_event_notif_tree_cb,
             sub.handle,
             flags,
@@ -1268,7 +1273,7 @@ class SysrepoSession:
             raise TypeError("notification must be a libyang.DNode")
         # libyang and sysrepo bindings are different, casting is required
         in_dnode = ffi.cast("struct lyd_node *", notification.cdata)
-        check_call(lib.sr_event_notif_send_tree, self.cdata, in_dnode, timeout_ms, wait)
+        check_call(lib.sr_notif_send_tree, self.cdata, in_dnode, timeout_ms, wait)
 
     def notification_send(
         self, xpath: str, notification: Dict, strict: bool = False

--- a/sysrepo/session.py
+++ b/sysrepo/session.py
@@ -1184,11 +1184,11 @@ class SysrepoSession:
             raise TypeError("rpc_input must be a libyang.DNode")
         # libyang and sysrepo bindings are different, casting is required
         in_dnode = ffi.cast("struct lyd_node *", rpc_input.cdata)
-        out_dnode_p = ffi.new("struct lyd_node **")
-        check_call(lib.sr_rpc_send_tree, self.cdata, in_dnode, timeout_ms, out_dnode_p)
-        if not out_dnode_p[0]:
+        sr_data_p = ffi.new("sr_data_t **")
+        check_call(lib.sr_rpc_send_tree, self.cdata, in_dnode, timeout_ms, sr_data_p)
+        if not sr_data_p[0]:
             raise SysrepoInternalError("sr_rpc_send_tree returned NULL")
-        return libyang.DNode.new(self.get_ly_ctx(), out_dnode_p[0])
+        return libyang.DNode.new(self.get_ly_ctx(), sr_data_p[0].tree)
 
     def rpc_send(
         self,

--- a/sysrepo/session.py
+++ b/sysrepo/session.py
@@ -443,7 +443,7 @@ class SysrepoSession:
         flags = _subscribe_flags(no_thread=no_thread)
 
         check_call(
-            lib.sr_oper_get_items_subscribe,
+            lib.sr_oper_get_subscribe,
             self.cdata,
             str2c(module),
             str2c(xpath),

--- a/sysrepo/session.py
+++ b/sysrepo/session.py
@@ -1052,7 +1052,7 @@ class SysrepoSession:
         """
         ctx = self.get_ly_ctx()
         module = ctx.get_module(module_name)
-        dnode = module.parse_data_dict(edit, edit=True, strict=strict, validate=False)
+        dnode = module.parse_data_dict(edit, strict=strict, validate=False)
         if not dnode:
             raise ValueError("provided config dict is empty")
         try:

--- a/sysrepo/session.py
+++ b/sysrepo/session.py
@@ -929,6 +929,7 @@ class SysrepoSession:
         # customize the free method to use the sysrepo free
         def sysrepo_free(cdata):
             lib.sr_release_data(sr_data_p[0])
+
         dnode.free_func = sysrepo_free
 
         return dnode

--- a/sysrepo/session.py
+++ b/sysrepo/session.py
@@ -181,7 +181,6 @@ class SysrepoSession:
         """
         It can only be called on an implicit sysrepo.Session (i.e., it can only be
         called from an event callback).
-        It only works with netopeer2.
 
         :returns: the NETCONF session ID set for the event originator sysrepo session
         """
@@ -205,15 +204,11 @@ class SysrepoSession:
         """
         It can only be called on an implicit sysrepo.Session (i.e., it can only be
         called from an event callback)
-        It only works with netopeer2.
 
         :returns: the effective username of the event originator sysrepo session
         """
         if not self.is_implicit:
             raise SysrepoUnsupportedError("can only report user on implicit sessions")
-
-        if self.get_originator_name() != "netopeer2":
-            raise SysrepoUnsupportedError("can only report netconf id for netopeer2")
 
         size = ffi.new("uint32_t *")
         p_user = ffi.new("const void **")

--- a/sysrepo/session.py
+++ b/sysrepo/session.py
@@ -66,12 +66,6 @@ class SysrepoSession:
         if self.is_implicit:
             raise SysrepoUnsupportedError("implicit sessions cannot be stopped")
 
-        # clear contexts
-        conn = lib.sr_session_get_connection(self.cdata)
-        for _ in range(self.num_contexts):
-            lib.sr_release_context(conn)
-        self.num_contexts = 0
-
         # clear subscriptions
         while self.subscriptions:
             sub = self.subscriptions.pop()
@@ -79,6 +73,14 @@ class SysrepoSession:
                 sub.unsubscribe()
             except Exception:
                 LOG.exception("Subscription.unsubscribe failed")
+
+        # clear contexts
+        conn = lib.sr_session_get_connection(self.cdata)
+        for _ in range(self.num_contexts):
+            lib.sr_release_context(conn)
+        self.num_contexts = 0
+
+        # stop session
         try:
             check_call(lib.sr_session_stop, self.cdata)
         finally:
@@ -708,7 +710,7 @@ class SysrepoSession:
         node_p = ffi.new("struct lyd_node **")
         prev_val_p = ffi.new("char **")
         prev_list_p = ffi.new("char **")
-        prev_dflt_p = ffi.new("bool *")
+        prev_dflt_p = ffi.new("int *")
         ctx = self.get_ly_ctx()
 
         try:

--- a/sysrepo/session.py
+++ b/sysrepo/session.py
@@ -925,8 +925,12 @@ class SysrepoSession:
         if not sr_data_p[0]:
             raise SysrepoNotFoundError(xpath)
         dnode = libyang.DNode.new(self.get_ly_ctx(), sr_data_p[0].tree).root()
+
         # customize the free method to use the sysrepo free
-        dnode.free = lambda: lib.sr_release_data(sr_data_p[0])
+        def sysrepo_free(cdata):
+            lib.sr_release_data(sr_data_p[0])
+        dnode.free_func = sysrepo_free
+
         return dnode
 
     def get_data(

--- a/sysrepo/session.py
+++ b/sysrepo/session.py
@@ -144,7 +144,6 @@ class SysrepoSession:
 
         return c2str(lib.sr_session_get_orig_name(self.cdata))
 
-
     def get_netconf_id(self) -> int:
         """
         It can only be called on an implicit sysrepo.Session (i.e., it can only be
@@ -158,10 +157,8 @@ class SysrepoSession:
                 "can only report netconf id on implicit sessions"
             )
 
-        if self.get_originator_name() != 'netopeer2':
-            raise SysrepoUnsupportedError(
-                "can only report netconf id for netopeer2"
-            )
+        if self.get_originator_name() != "netopeer2":
+            raise SysrepoUnsupportedError("can only report netconf id for netopeer2")
 
         size = ffi.new("uint32_t *")
         p_nc_id = ffi.new("const void **")
@@ -183,10 +180,8 @@ class SysrepoSession:
         if not self.is_implicit:
             raise SysrepoUnsupportedError("can only report user on implicit sessions")
 
-        if self.get_originator_name() != 'netopeer2':
-            raise SysrepoUnsupportedError(
-                "can only report netconf id for netopeer2"
-            )
+        if self.get_originator_name() != "netopeer2":
+            raise SysrepoUnsupportedError("can only report netconf id for netopeer2")
 
         size = ffi.new("uint32_t *")
         p_user = ffi.new("const void **")
@@ -1219,7 +1214,9 @@ class SysrepoSession:
         finally:
             out_dnode.free()
 
-    def notification_send_ly(self, notification: libyang.DNode, timeout_ms: int = 0, wait: bool = False) -> None:
+    def notification_send_ly(
+        self, notification: libyang.DNode, timeout_ms: int = 0, wait: bool = False
+    ) -> None:
         """
         Send a notification
 

--- a/sysrepo/subscription.py
+++ b/sysrepo/subscription.py
@@ -177,7 +177,7 @@ NOTIF_TYPES = {
 
 # ------------------------------------------------------------------------------
 @ffi.def_extern(name="srpy_module_change_cb")
-def module_change_callback(session, module, xpath, event, req_id, priv):
+def module_change_callback(session, sub_id, module, xpath, event, req_id, priv):
     """
     Callback to be called on the event of changing datastore content of the specified
     module.
@@ -188,6 +188,8 @@ def module_change_callback(session, module, xpath, event, req_id, priv):
 
     :arg "sr_session_ctx_t *" session:
         Implicit session (do not stop) with information about the changed data.
+    :arg "uint32_t" sub_id:
+        Subscription ID.
     :arg "const char *" module:
         Name of the module where the change has occurred.
     :arg "const char *" xpath:

--- a/sysrepo/subscription.py
+++ b/sysrepo/subscription.py
@@ -302,12 +302,14 @@ def module_change_callback(session, sub_id, module, xpath, event, req_id, priv):
 
 # ------------------------------------------------------------------------------
 @ffi.def_extern(name="srpy_oper_data_cb")
-def oper_data_callback(session, module, xpath, req_xpath, req_id, parent, priv):
+def oper_data_callback(session, sub_id, module, xpath, req_xpath, req_id, parent, priv):
     """
     Callback to be called when operational data at the selected xpath are requested.
 
     :arg "sr_session_ctx_t *" session:
         Implicit session (do not stop).
+    :arg "uint32_t" sub_id:
+        Subscription ID.
     :arg "const char *" module:
         Name of the affected module.
     :arg "const char *" xpath:
@@ -379,7 +381,7 @@ def oper_data_callback(session, module, xpath, req_xpath, req_id, parent, priv):
             # convert oper_data to a libyang.DNode object
             ly_ctx = session.get_ly_ctx()
             dnode = ly_ctx.get_module(module).parse_data_dict(
-                oper_data, data=True, strict=subscription.strict, validate=False
+                oper_data, strict=subscription.strict, validate=False
             )
             if dnode is not None:
                 if parent[0]:
@@ -413,12 +415,14 @@ def oper_data_callback(session, module, xpath, req_xpath, req_id, parent, priv):
 
 # ------------------------------------------------------------------------------
 @ffi.def_extern(name="srpy_rpc_tree_cb")
-def rpc_callback(session, xpath, input_node, event, req_id, output_node, priv):
+def rpc_callback(session, sub_id, xpath, input_node, event, req_id, output_node, priv):
     """
     Callback to be called for the delivery of an RPC/action.
 
     :arg "sr_session_ctx_t *" session:
         Implicit session (do not stop).
+    :arg "uint32_t" sub_id:
+        Subscription ID.
     :arg "const char *" xpath:
         Simple operation path identifying the RPC/action.
     :arg "const struct lyd_node *" input_node:

--- a/sysrepo/subscription.py
+++ b/sysrepo/subscription.py
@@ -559,7 +559,7 @@ def event_notif_tree_callback(session, sub_id, notif_type, notif, timestamp, pri
     """
     try:
         notif_type = NOTIF_TYPES[notif_type]
-        if notif_type == 'terminated' or notif == ffi.NULL:
+        if notif_type == "terminated" or notif == ffi.NULL:
             return
 
         # convert C arguments to python objects.

--- a/sysrepo/subscription.py
+++ b/sysrepo/subscription.py
@@ -170,7 +170,7 @@ NOTIF_TYPES = {
     lib.SR_EV_NOTIF_REALTIME: "realtime",
     lib.SR_EV_NOTIF_REPLAY: "replay",
     lib.SR_EV_NOTIF_REPLAY_COMPLETE: "replay_complete",
-    lib.SR_EV_NOTIF_STOP: "stop",
+    lib.SR_EV_NOTIF_TERMINATED: "stop",
     lib.SR_EV_NOTIF_SUSPENDED: "suspended",
     lib.SR_EV_NOTIF_RESUMED: "resumed",
 }
@@ -281,7 +281,7 @@ def module_change_callback(session, module, xpath, event, req_id, priv):
             and isinstance(session, SysrepoSession)
             and isinstance(xpath, str)
         ):
-            session.set_error(xpath, e.msg)
+            session.set_error(e.msg)
         return e.rc
 
     except BaseException as e:
@@ -294,7 +294,7 @@ def module_change_callback(session, module, xpath, event, req_id, priv):
             and isinstance(session, SysrepoSession)
             and isinstance(xpath, str)
         ):
-            session.set_error(xpath, str(e))
+            session.set_error(str(e))
         return lib.SR_ERR_CALLBACK_FAILED
 
 
@@ -396,7 +396,7 @@ def oper_data_callback(session, module, xpath, req_xpath, req_id, parent, priv):
 
     except SysrepoError as e:
         if e.msg and isinstance(session, SysrepoSession) and isinstance(xpath, str):
-            session.set_error(xpath, e.msg)
+            session.set_error(e.msg)
         return e.rc
 
     except BaseException as e:
@@ -405,7 +405,7 @@ def oper_data_callback(session, module, xpath, req_xpath, req_id, parent, priv):
         # We are in a C callback, we cannot let any error pass
         LOG.exception("%r callback failed", locals().get("callback", priv))
         if isinstance(session, SysrepoSession) and isinstance(xpath, str):
-            session.set_error(xpath, str(e))
+            session.set_error(str(e))
         return lib.SR_ERR_CALLBACK_FAILED
 
 
@@ -515,7 +515,7 @@ def rpc_callback(session, xpath, input_node, event, req_id, output_node, priv):
 
     except SysrepoError as e:
         if e.msg and isinstance(session, SysrepoSession) and isinstance(xpath, str):
-            session.set_error(xpath, e.msg)
+            session.set_error(e.msg)
         return e.rc
 
     except BaseException as e:
@@ -524,7 +524,7 @@ def rpc_callback(session, xpath, input_node, event, req_id, output_node, priv):
         # We are in a C callback, we cannot let any error pass
         LOG.exception("%r callback failed", locals().get("callback", priv))
         if isinstance(session, SysrepoSession) and isinstance(xpath, str):
-            session.set_error(xpath, str(e))
+            session.set_error(str(e))
         return lib.SR_ERR_CALLBACK_FAILED
 
 

--- a/sysrepo/subscription.py
+++ b/sysrepo/subscription.py
@@ -130,7 +130,7 @@ class Subscription:
         """
         Called when self.fd becomes readable.
         """
-        check_call(lib.sr_process_events, self.cdata, ffi.NULL, ffi.NULL)
+        check_call(lib.sr_subscription_process_events, self.cdata, ffi.NULL, ffi.NULL)
 
     def task_done(self, task_id: Any, event: str, task: asyncio.Task) -> None:
         """

--- a/tests/test_connection.py
+++ b/tests/test_connection.py
@@ -50,6 +50,6 @@ class ConnectionTest(unittest.TestCase):
         with sysrepo.SysrepoConnection() as conn:
             conn.remove_module("sysrepo-example")
         with sysrepo.SysrepoConnection() as conn:
-            ctx = conn.get_ly_ctx()
-            with self.assertRaises(libyang.LibyangError):
-                ctx.get_module("sysrepo-example")
+            with conn.get_ly_ctx() as ctx:
+                with self.assertRaises(libyang.LibyangError):
+                    ctx.get_module("sysrepo-example")

--- a/tests/test_connection.py
+++ b/tests/test_connection.py
@@ -27,13 +27,13 @@ class ConnectionTest(unittest.TestCase):
             pass
 
     def test_conn_start_session(self):
-        with sysrepo.SysrepoConnection(no_sched_changes=True) as conn:
+        with sysrepo.SysrepoConnection() as conn:
             sess = conn.start_session()
             self.assertEqual(sess.get_datastore(), "running")
             sess.stop()
 
     def test_conn_start_session_ctxmgr(self):
-        with sysrepo.SysrepoConnection(err_on_sched_fail=True) as conn:
+        with sysrepo.SysrepoConnection() as conn:
             with conn.start_session() as sess:
                 self.assertEqual(sess.get_datastore(), "running")
 
@@ -45,18 +45,11 @@ class ConnectionTest(unittest.TestCase):
     def test_conn_install_module(self):
         with sysrepo.SysrepoConnection() as conn:
             conn.install_module(YANG_FILE, enabled_features=["turbo"])
-        # reconnect to make sure it is installed
-        with sysrepo.SysrepoConnection(err_on_sched_fail=True) as conn:
-            ctx = conn.get_ly_ctx()
-            mod = ctx.get_module("sysrepo-example")
-            self.assertTrue(mod.implemented())
-            self.assertTrue(mod.feature_state("turbo"))
 
     def test_conn_remove_module(self):
         with sysrepo.SysrepoConnection() as conn:
             conn.remove_module("sysrepo-example")
-        # reconnect to make sure it is removed
-        with sysrepo.SysrepoConnection(err_on_sched_fail=True) as conn:
+        with sysrepo.SysrepoConnection() as conn:
             ctx = conn.get_ly_ctx()
             with self.assertRaises(libyang.LibyangError):
                 ctx.get_module("sysrepo-example")

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -19,17 +19,13 @@ sysrepo.configure_logging(stderr_level=logging.ERROR)
 class SessionTest(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
-        with sysrepo.SysrepoConnection() as conn:
-            conn.install_module(YANG_FILE, enabled_features=["turbo"])
-        cls.conn = sysrepo.SysrepoConnection(err_on_sched_fail=True)
+        cls.conn = sysrepo.SysrepoConnection()
+        cls.conn.install_module(YANG_FILE, enabled_features=["turbo"])
 
     @classmethod
     def tearDownClass(cls):
         cls.conn.remove_module("sysrepo-example")
         cls.conn.disconnect()
-        # reconnect to make sure module is removed
-        with sysrepo.SysrepoConnection(err_on_sched_fail=True):
-            pass
 
     def test_session_switch_ds(self):
         with self.conn.start_session("running") as sess:

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -41,8 +41,8 @@ class SessionTest(unittest.TestCase):
 
     def test_session_get_ly_ctx(self):
         with self.conn.start_session() as sess:
-            ctx = sess.get_ly_ctx()
-            mod = ctx.get_module("sysrepo-example")
+            with sess.get_ly_ctx() as ctx:
+                mod = ctx.get_module("sysrepo-example")
             self.assertTrue(mod.implemented)
 
     def test_session_get_data(self):

--- a/tests/test_subs_module_change.py
+++ b/tests/test_subs_module_change.py
@@ -184,13 +184,6 @@ class ModuleChangeSubscriptionTest(unittest.TestCase):
                     },
                 }
             }
-            # sysrepo v1 behavior
-            # expected_changes = [
-            #    sysrepo.ChangeMoved(
-            #        "/sysrepo-example:conf/network/interface[name='eth2']",
-            #        after="[name='eth0']",
-            #    ),
-            # ]
             expected_changes = [
                 sysrepo.ChangeMoved(
                     "/sysrepo-example:conf/network/interface[name='eth0']", after=""

--- a/tests/test_subs_module_change.py
+++ b/tests/test_subs_module_change.py
@@ -185,16 +185,15 @@ class ModuleChangeSubscriptionTest(unittest.TestCase):
                 }
             }
             # sysrepo v1 behavior
-            #expected_changes = [
+            # expected_changes = [
             #    sysrepo.ChangeMoved(
             #        "/sysrepo-example:conf/network/interface[name='eth2']",
             #        after="[name='eth0']",
             #    ),
-            #]
+            # ]
             expected_changes = [
                 sysrepo.ChangeMoved(
-                    "/sysrepo-example:conf/network/interface[name='eth0']",
-                    after=""
+                    "/sysrepo-example:conf/network/interface[name='eth0']", after=""
                 ),
             ]
             ch_sess.replace_config(sent_config, "sysrepo-example", strict=True)

--- a/tests/test_subs_module_change.py
+++ b/tests/test_subs_module_change.py
@@ -211,7 +211,7 @@ class ModuleChangeSubscriptionTest(unittest.TestCase):
             self.assertIn("user", kwargs)
             self.assertEqual(getpass.getuser(), kwargs["user"])
             self.assertIn("netconf_id", kwargs)
-            self.assertIsInstance(kwargs["netconf_id"], int)
+            self.assertEqual(12, kwargs["netconf_id"])
             calls.append((event, req_id, changes, private_data, kwargs))
 
         self.sess.subscribe_module_change(
@@ -223,6 +223,8 @@ class ModuleChangeSubscriptionTest(unittest.TestCase):
         )
 
         with self.conn.start_session("running") as ch_sess:
+            ch_sess.set_extra_info("netopeer2", 12, getpass.getuser())
+
             sent_config = {"conf": {"system": {"hostname": "bar"}}}
             ch_sess.replace_config(sent_config, "sysrepo-example", strict=True)
             # Successful change callbacks are called twice:

--- a/tests/test_subs_notification.py
+++ b/tests/test_subs_notification.py
@@ -26,8 +26,10 @@ class NotificationSubscriptionTest(unittest.TestCase):
 
     @classmethod
     def tearDownClass(cls):
-        cls.conn.remove_module("sysrepo-example")
+        # we have to disconnect first to release all resources
         cls.conn.disconnect()
+        with sysrepo.SysrepoConnection() as c:
+            c.remove_module("sysrepo-example")
 
     def _test_notification_sub(
         self,

--- a/tests/test_subs_notification.py
+++ b/tests/test_subs_notification.py
@@ -21,17 +21,13 @@ sysrepo.configure_logging(stderr_level=logging.ERROR)
 class NotificationSubscriptionTest(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
-        with sysrepo.SysrepoConnection() as conn:
-            conn.install_module(YANG_FILE, enabled_features=["turbo"])
-        cls.conn = sysrepo.SysrepoConnection(err_on_sched_fail=True)
+        cls.conn = sysrepo.SysrepoConnection()
+        cls.conn.install_module(YANG_FILE, enabled_features=["turbo"])
 
     @classmethod
     def tearDownClass(cls):
         cls.conn.remove_module("sysrepo-example")
         cls.conn.disconnect()
-        # reconnect to make sure module is removed
-        with sysrepo.SysrepoConnection(err_on_sched_fail=True):
-            pass
 
     def _test_notification_sub(
         self,

--- a/tests/test_subs_notification.py
+++ b/tests/test_subs_notification.py
@@ -53,7 +53,7 @@ class NotificationSubscriptionTest(unittest.TestCase):
                 self.assertIn("user", kwargs)
                 self.assertEqual(getpass.getuser(), kwargs["user"])
                 self.assertIn("netconf_id", kwargs)
-                self.assertIsInstance(kwargs["netconf_id"], int)
+                self.assertEqual(kwargs["netconf_id"], 12)
             else:
                 self.assertEqual(0, len(kwargs))
 
@@ -69,6 +69,9 @@ class NotificationSubscriptionTest(unittest.TestCase):
             )
 
             with self.conn.start_session() as sending_session:
+                if request_extra_info:
+                    sending_session.set_extra_info("netopeer2", 12, getpass.getuser())
+
                 sending_session.notification_send(notif_xpath, notif_dict)
                 self.assertTrue(
                     callback_called.wait(timeout=1),

--- a/tests/test_subs_oper.py
+++ b/tests/test_subs_oper.py
@@ -19,17 +19,13 @@ sysrepo.configure_logging(stderr_level=logging.ERROR)
 class OperSubscriptionTest(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
-        with sysrepo.SysrepoConnection() as conn:
-            conn.install_module(YANG_FILE, enabled_features=["turbo"])
-        cls.conn = sysrepo.SysrepoConnection(err_on_sched_fail=True)
+        cls.conn = sysrepo.SysrepoConnection()
+        cls.conn.install_module(YANG_FILE, enabled_features=["turbo"])
 
     @classmethod
     def tearDownClass(cls):
         cls.conn.remove_module("sysrepo-example")
         cls.conn.disconnect()
-        # reconnect to make sure module is removed
-        with sysrepo.SysrepoConnection(err_on_sched_fail=True):
-            pass
 
     def setUp(self):
         self.sess = self.conn.start_session()

--- a/tests/test_subs_rpc.py
+++ b/tests/test_subs_rpc.py
@@ -21,17 +21,13 @@ sysrepo.configure_logging(stderr_level=logging.ERROR)
 class RpcSubscriptionTest(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
-        with sysrepo.SysrepoConnection() as conn:
-            conn.install_module(YANG_FILE, enabled_features=["turbo"])
-        cls.conn = sysrepo.SysrepoConnection(err_on_sched_fail=True)
+        cls.conn = sysrepo.SysrepoConnection()
+        cls.conn.install_module(YANG_FILE, enabled_features=["turbo"])
 
     @classmethod
     def tearDownClass(cls):
         cls.conn.remove_module("sysrepo-example")
         cls.conn.disconnect()
-        # reconnect to make sure module is removed
-        with sysrepo.SysrepoConnection(err_on_sched_fail=True):
-            pass
 
     def test_rpc_sub(self):
         priv = object()

--- a/tox-install.sh
+++ b/tox-install.sh
@@ -33,7 +33,7 @@ download()
 	fi
 }
 
-ly_branch="${LIBYANG_BRANCH:-libyang1}"
+ly_branch="${LIBYANG_BRANCH:-devel}"
 ly_src="${LIBYANG_SRC:-$toxdir/.ly.$ly_branch.src}"
 ly_prefix="$toxdir/.ly.$ly_branch"
 ly_build="$toxdir/.ly.$ly_branch.build"
@@ -61,7 +61,7 @@ export LIBYANG_HEADERS="$ly_prefix/include"
 export LIBYANG_LIBRARIES="$ly_prefix/lib"
 export LIBYANG_EXTRA_LDFLAGS="-Wl,--enable-new-dtags,-rpath=$LIBYANG_LIBRARIES"
 
-sr_branch="${SYSREPO_BRANCH:-libyang1}"
+sr_branch="${SYSREPO_BRANCH:-master}"
 sr_src="${SYSREPO_SRC:-$toxdir/.sr.$sr_branch.src}"
 sr_prefix="$toxdir/.sr.$sr_branch"
 sr_build="$toxdir/.sr.$sr_branch.build"

--- a/tox-install.sh
+++ b/tox-install.sh
@@ -61,7 +61,7 @@ export LIBYANG_HEADERS="$ly_prefix/include"
 export LIBYANG_LIBRARIES="$ly_prefix/lib"
 export LIBYANG_EXTRA_LDFLAGS="-Wl,--enable-new-dtags,-rpath=$LIBYANG_LIBRARIES"
 
-sr_branch="${SYSREPO_BRANCH:-master}"
+sr_branch="${SYSREPO_BRANCH:-devel}"
 sr_src="${SYSREPO_SRC:-$toxdir/.sr.$sr_branch.src}"
 sr_prefix="$toxdir/.sr.$sr_branch"
 sr_build="$toxdir/.sr.$sr_branch.build"

--- a/tox.ini
+++ b/tox.ini
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: BSD-3-Clause
 
 [tox]
-envlist = format,lint,py{35,36,37,38,py3},py3-libyang1,coverage
+envlist = format,lint,py{35,36,37,38,py3},coverage
 skip_missing_interpreters = true
 isolated_build = true
 distdir = {toxinidir}/dist
@@ -17,8 +17,6 @@ install_command = {toxinidir}/tox-install.sh {toxworkdir} {opts} {packages}
 setenv =
 	SYSREPO_SHM_PREFIX = tox_{envname}
 	SYSREPO_REPOSITORY_PATH = {envdir}/etc/sysrepo
-	libyang1: LIBYANG_BRANCH = libyang1
-	libyang1: SYSREPO_BRANCH = libyang1
 whitelist_externals =
 	/bin/rm
 	/usr/bin/rm

--- a/tox.ini
+++ b/tox.ini
@@ -56,7 +56,7 @@ basepython = python3
 description = Format python code using isort and black.
 changedir = .
 deps =
-	black==20.8b1
+	black
 	isort
 skip_install = true
 install_command = python3 -m pip install {opts} {packages}
@@ -73,7 +73,7 @@ description = Run coding style checks.
 install_command = {toxinidir}/tox-install.sh {toxworkdir} {opts} {packages}
 changedir = .
 deps =
-	black==20.8b1
+	black
 	flake8
 	flake8-copyright
 	isort

--- a/tox.ini
+++ b/tox.ini
@@ -35,8 +35,6 @@ install_command = {toxinidir}/tox-install.sh {envdir} {opts} {packages}
 setenv =
 	SYSREPO_SHM_PREFIX = tox_{envname}
 	SYSREPO_REPOSITORY_PATH = {envdir}/etc/sysrepo
-	LIBYANG_BRANCH = libyang1
-	SYSREPO_BRANCH = libyang1
 whitelist_externals =
 	/bin/rm
 	/usr/bin/rm


### PR DESCRIPTION
Since libyang2 migration, sysrepo-python is no more compatible with the
master branch of sysrepo. It's because sysrepo migrate to libyang2.

This patch adds the support of the new version of sysrepo.