### PR TITLE
connection: allow to enable feature in module

### DIFF
--- a/sysrepo/connection.py
+++ b/sysrepo/connection.py
@@ -175,3 +175,16 @@ class SysrepoConnection:
             Name of the module to remove.
         """
         check_call(lib.sr_remove_module, self.cdata, str2c(name), force)
+
+    def enable_module_feature(self, name: str, feature_name: str) -> None:
+        """
+        Enable a module feature.
+
+        :arg str name:
+            Name of the module.
+        :arg str feature_name:
+            Name of the feature.
+        """
+        check_call(
+            lib.sr_enable_module_feature, self.cdata, str2c(name), str2c(feature_name)
+        )

--- a/tests/test_connection.py
+++ b/tests/test_connection.py
@@ -46,6 +46,18 @@ class ConnectionTest(unittest.TestCase):
         with sysrepo.SysrepoConnection() as conn:
             conn.install_module(YANG_FILE, enabled_features=["turbo"])
 
+    def test_conn_enable_module_feature(self):
+        with sysrepo.SysrepoConnection() as conn:
+            conn.install_module(YANG_FILE)
+            conn.enable_module_feature("sysrepo-example", "turbo")
+            with conn.start_session("operational") as sess:
+                data = sess.get_data("/ietf-yang-library:*")
+                data = data["yang-library"]["module-set"]
+                data = next(iter(data))
+                data = data["module"]
+                data = [x for x in data if x["name"] == "sysrepo-example"][0]
+                self.assertIn("feature", data)
+
     def test_conn_remove_module(self):
         with sysrepo.SysrepoConnection() as conn:
             conn.remove_module("sysrepo-example")


### PR DESCRIPTION
Currently, feature can only be enabled at connection start. With this
patch, the feature can be enabled after the connection is created.

It allows to enable feature after all modules are loaded. Since the new
version of Sysrepo install module in a synchronous way, this function is
a must have.