### PR TITLE
session: add delete_oper_item

### DIFF
--- a/cffi/cdefs.h
+++ b/cffi/cdefs.h
@@ -186,6 +186,7 @@ int sr_rpc_send_tree(sr_session_ctx_t *, struct lyd_node *, uint32_t, sr_data_t 
 
 int sr_set_item_str(sr_session_ctx_t *, const char *, const char *, const char *, const sr_edit_options_t);
 int sr_delete_item(sr_session_ctx_t *, const char *, const sr_edit_options_t);
+int sr_oper_delete_item_str(sr_session_ctx_t *, const char *, const char *, const sr_edit_options_t);
 int sr_edit_batch(sr_session_ctx_t *, const struct lyd_node *, const char *);
 int sr_replace_config(sr_session_ctx_t *, const char *, struct lyd_node *, uint32_t);
 int sr_validate(sr_session_ctx_t *, const char *, uint32_t);

--- a/sysrepo/session.py
+++ b/sysrepo/session.py
@@ -1050,6 +1050,29 @@ class SysrepoSession:
         """
         check_call(lib.sr_delete_item, self.cdata, str2c(xpath), 0)
 
+    def delete_oper_item(self, xpath: str, value: Any = None) -> None:
+        """
+        Prepare to delete the nodes matching the specified xpath in the operational
+        datastore. These changes are applied only after calling
+        apply_changes().
+
+        :arg xpath:
+            Path identifier of the data element to be deleted.
+        :arg value:
+            String representation of the value deleted.
+
+        :raises SysrepoNotFoundError:
+            If no nodes match the path.
+        """
+        if value is not None and not isinstance(value, str):
+            if isinstance(value, bool):
+                value = str(value).lower()
+            else:
+                value = str(value)
+        check_call(
+            lib.sr_oper_delete_item_str, self.cdata, str2c(xpath), str2c(value), 0
+        )
+
     def edit_batch_ly(
         self, edit: libyang.DNode, default_operation: str = "merge"
     ) -> None:


### PR DESCRIPTION
Sysrepo does not allow anymore to use sr_delete_item on the operational
datastore. The new sr_oper_delete_item_str function must be used.
Wrap it into the delete_oper_item function.

Signed-off-by: Samuel Gauthier <samuel.gauthier@6wind.com>