### PR TITLE
Optionally retrieve values in ChangeDeleted

### DIFF
--- a/sysrepo/change.py
+++ b/sysrepo/change.py
@@ -31,6 +31,7 @@ class Change:
         prev_list: str,
         prev_dflt: bool,
         include_implicit_defaults: bool = True,
+        include_deleted_values: bool = False,
     ) -> "Change":
         """
         Parse an operation code and values from libsysrepo.so and return a Change
@@ -64,6 +65,8 @@ class Change:
             Previous value default flag, depends on the operation.
         :arg include_implicit_defaults:
             Include implicit default values into the data dictionaries.
+        :arg include_deleted_values:
+            Include deleted nodes values.
         """
         if operation == lib.SR_OP_CREATED:
             if not node.should_print(
@@ -83,8 +86,8 @@ class Change:
                 prev_dflt=prev_dflt,
             )
         if operation == lib.SR_OP_DELETED:
-            if isinstance(node, (libyang.DLeaf, libyang.DLeafList)):
-                value = node.value()
+            if include_deleted_values:
+                value = _node_value(node, include_implicit_defaults)
             else:
                 value = None
             return ChangeDeleted(node.path(), value)

--- a/sysrepo/session.py
+++ b/sysrepo/session.py
@@ -293,6 +293,7 @@ class SysrepoSession:
         private_data: Any = None,
         asyncio_register: bool = False,
         include_implicit_defaults: bool = True,
+        include_deleted_values: bool = False,
         extra_info: bool = False,
     ) -> None:
         """
@@ -329,6 +330,8 @@ class SysrepoSession:
             monitored read file descriptors. Implies `no_thread=True`.
         :arg include_implicit_defaults:
             Include implicit default nodes in changes.
+        :arg include_deleted_values:
+            Include deleted nodes values in changes.
         :arg extra_info:
             When True, the given callback is called with extra keyword arguments
             containing extra information of the sysrepo session that gave origin to the
@@ -343,6 +346,7 @@ class SysrepoSession:
             private_data,
             asyncio_register=asyncio_register,
             include_implicit_defaults=include_implicit_defaults,
+            include_deleted_values=include_deleted_values,
             extra_info=extra_info,
         )
         sub_p = ffi.new("sr_subscription_ctx_t **")
@@ -732,7 +736,10 @@ class SysrepoSession:
 
     # begin: changes
     def get_changes(
-        self, xpath: str, include_implicit_defaults: bool = True
+        self,
+        xpath: str,
+        include_implicit_defaults: bool = True,
+        include_deleted_values: bool = False,
     ) -> Iterator[Change]:
         """
         Return an iterator that will yield all pending changes in the current session.
@@ -743,6 +750,8 @@ class SysrepoSession:
             appended to the XPath.
         :arg include_implicit_defaults:
             Include implicit default nodes.
+        :arg include_deleted_values:
+            Include deleted node values into the returned Change objects.
 
         :returns:
             An iterator that will yield `sysrepo.Change` objects.
@@ -778,6 +787,7 @@ class SysrepoSession:
                             prev_list=c2str(prev_list_p[0]),
                             prev_dflt=bool(prev_dflt_p[0]),
                             include_implicit_defaults=include_implicit_defaults,
+                            include_deleted_values=include_deleted_values,
                         )
                 except Change.Skip:
                     pass

--- a/sysrepo/subscription.py
+++ b/sysrepo/subscription.py
@@ -33,6 +33,7 @@ class Subscription:
         asyncio_register: bool = False,
         strict: bool = False,
         include_implicit_defaults: bool = True,
+        include_deleted_values: bool = False,
         extra_info: bool = False,
     ):
         """
@@ -50,6 +51,9 @@ class Subscription:
         :arg include_implicit_defaults:
             If True, include implicit default nodes into Change objects passed to module
             change callbacks and into input parameters passed to RPC/action callbacks.
+        :arg include_deleted_values:
+            If True, include the complete deleted node values into Change objects passed
+            to module change callbacks.
         :arg extra_info:
             When True, the given callback is called with extra keyword arguments
             containing extra information of the sysrepo session that gave origin to the
@@ -64,6 +68,7 @@ class Subscription:
         self.asyncio_register = asyncio_register
         self.strict = strict
         self.include_implicit_defaults = include_implicit_defaults
+        self.include_deleted_values = include_deleted_values
         self.extra_info = extra_info
         if asyncio_register:
             self.loop = asyncio.get_event_loop()
@@ -242,6 +247,7 @@ def module_change_callback(session, sub_id, module, xpath, event, req_id, priv):
                     session.get_changes(
                         root_xpath + "//.",
                         include_implicit_defaults=subscription.include_implicit_defaults,
+                        include_deleted_values=subscription.include_deleted_values,
                     )
                 )
                 task = subscription.loop.create_task(
@@ -270,6 +276,7 @@ def module_change_callback(session, sub_id, module, xpath, event, req_id, priv):
                 session.get_changes(
                     root_xpath + "//.",
                     include_implicit_defaults=subscription.include_implicit_defaults,
+                    include_deleted_values=subscription.include_deleted_values,
                 )
             )
             callback(event_name, req_id, changes, private_data, **extra_info)


### PR DESCRIPTION
From #32. Now values are retrieved in `ChangeDeleted` for `List` and `Container` node types and getting deleted values is optional, configurable by user application with `include_deleted_values` when subscription is created (by default, `False`, it does not get deleted values).

Added some tests for this functionality.