### PR TITLE
Add module_name to Session.validate()

### DIFF
--- a/sysrepo/session.py
+++ b/sysrepo/session.py
@@ -1180,7 +1180,7 @@ class SysrepoSession:
         dnode = module.parse_data_dict(config, strict=strict, validate=False)
         self.replace_config_ly(dnode, module_name, timeout_ms=timeout_ms)
 
-    def validate(self) -> None:
+    def validate(self, module_name: str = None) -> None:
         """
         Perform the validation a datastore and any changes made in the current
         session, but do not apply nor discard them.
@@ -1188,12 +1188,16 @@ class SysrepoSession:
         Provides only YANG validation, apply-changes **subscribers will not be
         notified** in this case.
 
+        :arg module_name:
+            If specified, limits the validate operation only to this module and its
+            dependencies.
+
         :raises SysrepoError:
             If validation failed.
         """
         if self.is_implicit:
             raise SysrepoUnsupportedError("cannot validate with implicit sessions")
-        check_call(lib.sr_validate, self.cdata, 0)
+        check_call(lib.sr_validate, self.cdata, str2c(module_name), 0)
 
     def apply_changes(self, timeout_ms: int = 0) -> None:
         """


### PR DESCRIPTION
I have noticed that `module_name` param is missing in `Session.validate()`, so it is not being passed to `sr_validate` and it fails with a `TypeError`. See `sr_validate` definition [here](https://netopeer.liberouter.org/doc/sysrepo/master/html/group__edit__data__api.html#ga04d3e8cc206f55d7880a406da3ddf005).

For backwards compatibility, I have added it as optional argument:

```python
def validate(self, module_name: str = None) -> None:
```

Also, this function was not being tested, so I have modified the tests.