### PR TITLE
callback: return session when sync change callback is used

### DIFF
--- a/examples/application.py
+++ b/examples/application.py
@@ -42,6 +42,12 @@ def main():
             with conn.start_session() as sess:
                 logging.info("subscribing to module changes: sysrepo-example")
                 sess.subscribe_module_change("sysrepo-example", None, module_change_cb)
+                sess.subscribe_module_change_unsafe(
+                    "sysrepo-example",
+                    None,
+                    module_change_unsafe_cb,
+                    priority=1,
+                )
                 logging.info(
                     "subscribing to operational data requests: /sysrepo-example:state"
                 )
@@ -69,6 +75,19 @@ def module_change_cb(event, req_id, changes, private_data):
     print("========================")
     print("Module changed event: %s (request ID %s)" % (event, req_id))
     print("----- changes -----")
+    for c in changes:
+        print(repr(c))
+    print("----- end of changes -----")
+    print()
+
+
+# ------------------------------------------------------------------------------
+def module_change_unsafe_cb(session, event, req_id, private_data):
+    print()
+    print("========================")
+    print("(unsafe) Module changed event: %s (request ID %s)" % (event, req_id))
+    print("----- changes -----")
+    changes = list(session.get_changes("/sysrepo-example:conf//."))
     for c in changes:
         print(repr(c))
     print("----- end of changes -----")

--- a/tests/test_subs_module_change.py
+++ b/tests/test_subs_module_change.py
@@ -7,6 +7,7 @@ import os
 import unittest
 
 import sysrepo
+from sysrepo.session import SysrepoSession
 
 
 YANG_FILE = os.path.join(
@@ -307,3 +308,163 @@ class ModuleChangeSubscriptionTest(unittest.TestCase):
             #   * once with event "change"
             #   * once with event "done"
             self.assertEqual(2, len(calls))
+
+    def test_module_change_sub_unsafe(self):
+        priv = object()
+        current_config = {}
+        expected_changes = []
+
+        def module_change_cb(session, event, req_id, private_data):
+            self.assertIsInstance(session, SysrepoSession)
+            self.assertIn(event, ("change", "done", "abort"))
+            self.assertIsInstance(req_id, int)
+            self.assertIs(private_data, priv)
+            changes = list(session.get_changes("/sysrepo-example:conf//."))
+            for c in changes:
+                if c.xpath == "/sysrepo-example:conf/system/hostname":
+                    if event == "change" and c.value == "INVALID":
+                        raise sysrepo.SysrepoValidationFailedError("invalid hostname")
+            if event in ("change", "done"):
+                self.assertEqual(changes, expected_changes)
+            if event == "done":
+                sysrepo.update_config_cache(current_config, changes)
+
+        self.sess.subscribe_module_change_unsafe(
+            "sysrepo-example",
+            "/sysrepo-example:conf",
+            module_change_cb,
+            private_data=priv,
+        )
+
+        with self.conn.start_session("running") as ch_sess:
+            # 1.
+            sent_config = {"conf": {"system": {"hostname": "bar"}}}
+            expected_changes = [
+                sysrepo.ChangeCreated("/sysrepo-example:conf/system/hostname", "bar")
+            ]
+            ch_sess.replace_config(sent_config, "sysrepo-example", strict=True)
+            self.assertEqual(current_config, sent_config)
+            # 2.
+            sent_config = {"conf": {"system": {"hostname": "INVALID"}}}
+            expected_changes = []
+            with self.assertRaises(sysrepo.SysrepoCallbackFailedError):
+                ch_sess.replace_config(sent_config, "sysrepo-example", strict=True)
+            # 3.
+            sent_config = {
+                "conf": {
+                    "system": {"hostname": "bar"},
+                    "network": {"interface": [{"name": "eth0", "up": True}]},
+                }
+            }
+            expected_changes = [
+                sysrepo.ChangeCreated(
+                    "/sysrepo-example:conf/network/interface[name='eth0']",
+                    {"name": "eth0", "up": True},
+                    after="",
+                ),
+                sysrepo.ChangeCreated(
+                    "/sysrepo-example:conf/network/interface[name='eth0']/name", "eth0"
+                ),
+                sysrepo.ChangeCreated(
+                    "/sysrepo-example:conf/network/interface[name='eth0']/up", True
+                ),
+            ]
+            ch_sess.replace_config(sent_config, "sysrepo-example", strict=True)
+            self.assertEqual(current_config, sent_config)
+            # 4.
+            sent_config = {
+                "conf": {
+                    "system": {"hostname": "bar"},
+                    "network": {"interface": [{"name": "eth2", "up": False}]},
+                }
+            }
+            expected_changes = [
+                sysrepo.ChangeDeleted(
+                    "/sysrepo-example:conf/network/interface[name='eth0']",
+                    None,
+                ),
+                sysrepo.ChangeDeleted(
+                    "/sysrepo-example:conf/network/interface[name='eth0']/name",
+                    None,
+                ),
+                sysrepo.ChangeDeleted(
+                    "/sysrepo-example:conf/network/interface[name='eth0']/up",
+                    None,
+                ),
+                sysrepo.ChangeCreated(
+                    "/sysrepo-example:conf/network/interface[name='eth2']",
+                    {"name": "eth2", "up": False},
+                    after="",
+                ),
+                sysrepo.ChangeCreated(
+                    "/sysrepo-example:conf/network/interface[name='eth2']/name", "eth2"
+                ),
+                sysrepo.ChangeCreated(
+                    "/sysrepo-example:conf/network/interface[name='eth2']/up", False
+                ),
+            ]
+            ch_sess.replace_config(sent_config, "sysrepo-example", strict=True)
+            self.assertEqual(current_config, sent_config)
+            # 5.
+            sent_config = {
+                "conf": {
+                    "system": {"hostname": "bar"},
+                    "network": {"interface": [{"name": "eth2", "up": True}]},
+                }
+            }
+            expected_changes = [
+                sysrepo.ChangeModified(
+                    "/sysrepo-example:conf/network/interface[name='eth2']/up",
+                    True,
+                    "false",
+                    False,
+                ),
+            ]
+            ch_sess.replace_config(sent_config, "sysrepo-example", strict=True)
+            self.assertEqual(current_config, sent_config)
+            # 6.
+            sent_config = {
+                "conf": {
+                    "system": {"hostname": "bar"},
+                    "network": {
+                        "interface": [
+                            {"name": "eth2", "up": True},
+                            {"name": "eth0", "up": False},
+                        ]
+                    },
+                }
+            }
+            expected_changes = [
+                sysrepo.ChangeCreated(
+                    "/sysrepo-example:conf/network/interface[name='eth0']",
+                    {"name": "eth0", "up": False},
+                    after="[name='eth2']",
+                ),
+                sysrepo.ChangeCreated(
+                    "/sysrepo-example:conf/network/interface[name='eth0']/name", "eth0"
+                ),
+                sysrepo.ChangeCreated(
+                    "/sysrepo-example:conf/network/interface[name='eth0']/up", False
+                ),
+            ]
+            ch_sess.replace_config(sent_config, "sysrepo-example", strict=True)
+            self.assertEqual(current_config, sent_config)
+            # 7.
+            sent_config = {
+                "conf": {
+                    "system": {"hostname": "bar"},
+                    "network": {
+                        "interface": [
+                            {"name": "eth0", "up": False},
+                            {"name": "eth2", "up": True},
+                        ]
+                    },
+                }
+            }
+            expected_changes = [
+                sysrepo.ChangeMoved(
+                    "/sysrepo-example:conf/network/interface[name='eth0']", after=""
+                ),
+            ]
+            ch_sess.replace_config(sent_config, "sysrepo-example", strict=True)
+            self.assertEqual(current_config, sent_config)


### PR DESCRIPTION
From #49. I have not tested this yet, but I think it could be a first approach. I have introduced a second callback definition in `session` module and, in `subscription`, I directly pass to the callback the session instance that is currently being created.

Note that in line 251 I specified `Any` instead of `SysrepoSession` class, as that attribute is being declared inside the class itself. Any other option or suggestion is welcome.