### PR TITLE
session: implement discard_items

### DIFF
--- a/cffi/cdefs.h
+++ b/cffi/cdefs.h
@@ -188,6 +188,7 @@ void sr_release_data(sr_data_t *);
 int sr_rpc_send_tree(sr_session_ctx_t *, struct lyd_node *, uint32_t, sr_data_t **);
 
 int sr_set_item_str(sr_session_ctx_t *, const char *, const char *, const char *, const sr_edit_options_t);
+int sr_discard_items(sr_session_ctx_t *, const char *);
 int sr_delete_item(sr_session_ctx_t *, const char *, const sr_edit_options_t);
 int sr_oper_delete_item_str(sr_session_ctx_t *, const char *, const char *, const sr_edit_options_t);
 int sr_edit_batch(sr_session_ctx_t *, const struct lyd_node *, const char *);

--- a/sysrepo/session.py
+++ b/sysrepo/session.py
@@ -1159,6 +1159,18 @@ class SysrepoSession:
             lib.sr_set_item_str, self.cdata, str2c(xpath), str2c(value), ffi.NULL, 0
         )
 
+    def discard_items(self, xpath: str) -> None:
+        """
+        Prepare to discard nodes matching the specified xpath (or all if not
+        set) previously set by the session connection. Usable only for the
+        operational datastore . These changes are applied only after calling
+        apply_changes().
+
+        :arg xpath:
+            Path identifier of the data element to be deleted.
+        """
+        check_call(lib.sr_discard_items, self.cdata, str2c(xpath))
+
     def delete_item(self, xpath: str) -> None:
         """
         Prepare to delete the nodes matching the specified xpath. These changes

--- a/tests/test_subs_oper.py
+++ b/tests/test_subs_oper.py
@@ -99,7 +99,7 @@ class OperSubscriptionTest(unittest.TestCase):
         with self.conn.start_session("operational") as op_sess:
             op_sess.set_extra_info("netopeer2", 12, getpass.getuser())
             oper_data = op_sess.get_data(
-                "/sysrepo-example:state", keep_empty_containers=True
+                "/sysrepo-example:state", keep_empty_containers=False
             )
             self.assertEqual(len(calls), 1)
-            self.assertEqual(oper_data, {"state": {}})
+            self.assertEqual(oper_data, {})


### PR DESCRIPTION
This can be used to discard all the changes made by a session in the operational datastore. Fix the tests first, that were broken after a sysrepo update.