### PR TITLE
session: add copy_config support

### DIFF
--- a/cffi/cdefs.h
+++ b/cffi/cdefs.h
@@ -192,6 +192,7 @@ int sr_discard_items(sr_session_ctx_t *, const char *);
 int sr_delete_item(sr_session_ctx_t *, const char *, const sr_edit_options_t);
 int sr_oper_delete_item_str(sr_session_ctx_t *, const char *, const char *, const sr_edit_options_t);
 int sr_edit_batch(sr_session_ctx_t *, const struct lyd_node *, const char *);
+int sr_copy_config(sr_session_ctx_t *, const char *, sr_datastore_t, uint32_t);
 int sr_replace_config(sr_session_ctx_t *, const char *, struct lyd_node *, uint32_t);
 int sr_validate(sr_session_ctx_t *, const char *, uint32_t);
 int sr_apply_changes(sr_session_ctx_t *, uint32_t);

--- a/examples/sysrepocfg.py
+++ b/examples/sysrepocfg.py
@@ -43,6 +43,15 @@ def main():
         output is printed to stdout.
         """,
     )
+    group.add_argument(
+        "-C",
+        "--copy-from",
+        metavar="DATASTORE",
+        choices=("running", "startup", "operational", "candidate"),
+        help="""
+        Perform a copy-config from a datastore.
+        """,
+    )
     parser.add_argument(
         "-v", "--verbose", action="count", default=0, help="Increase verbosity."
     )
@@ -106,6 +115,9 @@ def main():
                         data.print_file(
                             sys.stdout, args.format, pretty=True, with_siblings=True
                         )
+
+                elif args.copy_from:
+                    sess.copy_config(args.copy_from)
 
                 elif args.rpc:
                     with conn.get_ly_ctx() as ctx:

--- a/sysrepo/session.py
+++ b/sysrepo/session.py
@@ -1314,6 +1314,35 @@ class SysrepoSession:
         dnode = module.parse_data_dict(config, strict=strict, validate=False)
         self.replace_config_ly(dnode, module_name, timeout_ms=timeout_ms)
 
+    def copy_config(
+        self, src_datastore: str, module_name: str = None, timeout_ms: int = 0
+    ) -> None:
+        """
+        Replaces a conventional datastore with the contents of another conventional
+        datastore. If the module is specified, limits the operation only to the
+        specified module. If it is not specified, the operation is performed on all
+        modules.
+
+        Note that copying from candidate to running or vice versa causes the candidate
+        datastore to revert to original behavior of mirroring running datastore
+        (datastores).
+
+        Required WRITE access.
+
+        :arg src_datastore:
+            Source datastore to copy configuration from. Can be one of `running`,
+            `startup`, `operational` or `candidate`. Must be a different datastore
+            than the session's.
+        :arg module_name:
+            Optional module name that limits the copy operation only to this module.
+        :arg timeout_ms:
+            Configuration callback timeout in milliseconds. If 0, default is used.
+        """
+        if self.is_implicit:
+            raise SysrepoUnsupportedError("cannot copy config from implicit sessions")
+        ds = datastore_value(src_datastore)
+        check_call(lib.sr_copy_config, self.cdata, str2c(module_name), ds, timeout_ms)
+
     def validate(self, module_name: str = None) -> None:
         """
         Perform the validation a datastore and any changes made in the current


### PR DESCRIPTION
Add support for copying/importing configuration from another datastore.

The equivalent of `sysrepocfg --copy-from candidate --datastore running` is:

```python
    with connection.start_session("running") as s:
        s.copy_config("candidate")
```

Fixes: https://github.com/sysrepo/sysrepo-python/issues/55