### PR TITLE
add sr_get_module_ds_access API

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -158,10 +158,10 @@ Supported Features
 __ https://pypi.org/project/libyang/
 .. _async: https://docs.python.org/3/library/asyncio-task.html#coroutine
 
-Not Yet Supported Features
---------------------------
+Partially Supported Features
+----------------------------
 
-All other features are not yet supported by sysrepo-python. The most notable
+All other features are not yet or only partially supported by sysrepo-python. The most notable
 are:
 
 -  Module management (``sr_*_module_*``)

--- a/cffi/cdefs.h
+++ b/cffi/cdefs.h
@@ -292,3 +292,6 @@ int sr_notif_subscribe_tree(sr_session_ctx_t *, const char *module_name, const c
 	void *priv, sr_subscr_options_t, sr_subscription_ctx_t **);
 
 int sr_notif_send_tree(sr_session_ctx_t *, struct lyd_node *notif, uint32_t timeout_ms, int wait);
+
+typedef int... mode_t;
+int sr_get_module_ds_access(sr_conn_ctx_t *conn, const char *module_name, int mod_ds, char **owner, char **group, mode_t *perm);

--- a/tests/test_connection.py
+++ b/tests/test_connection.py
@@ -1,8 +1,10 @@
 # Copyright (c) 2020 6WIND S.A.
 # SPDX-License-Identifier: BSD-3-Clause
 
+import grp
 import logging
 import os
+import pwd
 import unittest
 
 import libyang
@@ -77,3 +79,11 @@ class ConnectionTest(unittest.TestCase):
                 data = [x for x in data if x["name"] == "sysrepo-example"][0]
                 self.assertIn("feature", data)
             conn.remove_module("sysrepo-example")
+
+    def test_conn_get_module_infos(self):
+        with sysrepo.SysrepoConnection() as conn:
+            conn.install_module(YANG_FILE)
+            owner, group, perm = conn.get_module_ds_access("sysrepo-example")
+            self.assertEqual(pwd.getpwnam(owner).pw_uid, os.geteuid())
+            self.assertEqual(grp.getgrnam(group).gr_gid, os.getegid())
+            self.assertEqual(perm, 0o600)


### PR DESCRIPTION
In order to read the owner, group and permissions of a module, this PR adds binding for the `sr_get_module_ds_access` C function.

I'm not an expert with cffi, so let me know if there are things to improve :)
Do you think returning a tuple from the function is fine or would you expect a dedicated type?

Thanks in advance!