### PR TITLE
docs: fix typos

### DIFF
--- a/sysrepo/change.py
+++ b/sysrepo/change.py
@@ -196,7 +196,7 @@ def update_config_cache(conf: Dict, changes: List[Change]) -> None:
     Maintain a configuration dict from a list of Change objects.
 
     This function is intended to be used in module change callbacks if they want to
-    preserve a full view of all the configuration without asking sysrepo everytime the
+    preserve a full view of all the configuration without asking sysrepo every time the
     callback is invoked.
 
     :arg conf:

--- a/sysrepo/session.py
+++ b/sysrepo/session.py
@@ -1511,7 +1511,7 @@ class SysrepoSession:
         :arg strip_prefixes:
             If True, remove YANG module prefixes from dictionary keys.
         :arg include_implicit_defaults:
-            Include leaves with implicit default values in the retured dict.
+            Include leaves with implicit default values in the returned dict.
         :arg trim_default_values:
             Exclude leaves when their value equals the default.
         :arg keep_empty_containers:

--- a/sysrepo/subscription.py
+++ b/sysrepo/subscription.py
@@ -157,7 +157,7 @@ class Subscription:
                 self.process_events()
             else:
                 # Sysrepo does not care about the result of the callback.
-                # This will raise the exception here if any occured in the task
+                # This will raise the exception here if any occurred in the task
                 # and will be logged (i.e. not lost).
                 self.tasks.pop(task_id, None)
                 task.result()

--- a/sysrepo/value.py
+++ b/sysrepo/value.py
@@ -28,7 +28,7 @@ class Value:
         to ``None``.
         """
         if cls is Value:
-            raise TypeError("Value cannot be instanciated directly, use subclasses")
+            raise TypeError("Value cannot be instantiated directly, use subclasses")
         i = 0
         new_args = [cls]
         if cls.value_field is not None:


### PR DESCRIPTION
Found via `codespell -L astroid`