### PR TITLE
Add the xpath to UnsafeModuleChangeCallbackType

### DIFF
--- a/sysrepo/session.py
+++ b/sysrepo/session.py
@@ -416,7 +416,7 @@ class SysrepoSession:
 
         self.subscriptions.append(sub)
 
-    UnsafeModuleChangeCallbackType = Callable[["SysrepoSession", str, int, Any], None]
+    UnsafeModuleChangeCallbackType = Callable[["SysrepoSession", str, str, int, Any], None]
     """
     Callback to be called when the change in the datastore occurs. Provides implicit 
     session object instead of list of changes. THE CALLBACK SHOULD NEVER KEEP A
@@ -424,6 +424,8 @@ class SysrepoSession:
 
     :arg session:
         Implicit session (do not stop) with information about the changed data.
+    :arg xpath:
+        The xpath to the node or the module.
     :arg event:
         Type of the callback event that has occurred. Can be one of: "update", "change",
         "done", "abort", "enabled".

--- a/sysrepo/subscription.py
+++ b/sysrepo/subscription.py
@@ -233,7 +233,7 @@ def module_change_callback(session, sub_id, module, xpath, event, req_id, priv):
         private_data = subscription.private_data
         event_name = EVENT_NAMES[event]
         if subscription.unsafe:
-            callback(session, event_name, req_id, private_data)
+            callback(session, root_xpath, event_name, req_id, private_data)
             return lib.SR_ERR_OK
         if subscription.extra_info:
             try:

--- a/tests/test_subs_module_change.py
+++ b/tests/test_subs_module_change.py
@@ -314,8 +314,9 @@ class ModuleChangeSubscriptionTest(unittest.TestCase):
         current_config = {}
         expected_changes = []
 
-        def module_change_cb(session, event, req_id, private_data):
+        def module_change_cb(session, xpath, event, req_id, private_data):
             self.assertIsInstance(session, SysrepoSession)
+            self.assertEqual(xpath, "/sysrepo-example:conf")
             self.assertIn(event, ("change", "done", "abort"))
             self.assertIsInstance(req_id, int)
             self.assertIs(private_data, priv)


### PR DESCRIPTION
Pull Requst for the issue #78 

With the XPath in the callback we can get the subscribed changes. 
