### PR TITLE
fix: xpath filter passed to 'get_changes'

### DIFF
--- a/sysrepo/subscription.py
+++ b/sysrepo/subscription.py
@@ -4,6 +4,7 @@
 import asyncio
 import functools
 import logging
+import re
 from typing import Any, Callable
 
 from libyang.data import DNode
@@ -227,7 +228,9 @@ def module_change_callback(session, sub_id, module, xpath, event, req_id, priv):
         session = SysrepoSession(session, True)
         module = c2str(module)
         xpath = c2str(xpath)
-        root_xpath = ("/%s:*" % module) if xpath is None else xpath
+        # remove all filter conditions from 'xpath' as sysrepo already 
+        # provides changes that are filtered by the subscription's xpath
+        root_xpath = ("/%s:*" % module) if xpath is None else re.sub(r'\[.*?\]', '', xpath)
         subscription = ffi.from_handle(priv)
         callback = subscription.callback
         private_data = subscription.private_data


### PR DESCRIPTION
When an xpath is set then the sysrepo API already provides only filtered changes. Reapplying the same xpath doesn't work when the filter element is not part of the result. Hence, remove all filters when collecting the changes.

For example, the xpath "/ietf-interfaces:interfaces/interface[type='iana-if-type:ethernetCsmacd']/enabled" subscribes for changes of the 'enabled' leaf but 'type' is not part of the result, in which case get_changes(xpath + '//.', ...) will always be empty!

Hence, we need to remove any filter conditions from the xpath when collecting changes.

@rjarry Can you please review and, if accepted, merge?