### PR TITLE
add an option to compile obsolete nodes

### DIFF
--- a/cffi/cdefs.h
+++ b/cffi/cdefs.h
@@ -52,6 +52,7 @@ typedef enum {
     SR_CTX_DEFAULT,
     SR_CTX_NO_PRINTED,
     SR_CTX_SET_PRIV_PARSED,
+    SR_CTX_COMPILE_OBSOLETE,
     ...
 } sr_context_flag_t;
 

--- a/sysrepo/connection.py
+++ b/sysrepo/connection.py
@@ -36,7 +36,12 @@ class SysrepoConnection:
 
     __slots__ = ("cdata",)
 
-    def __init__(self, cache_running: bool = False, not_printed: bool = True):
+    def __init__(
+        self,
+        cache_running: bool = False,
+        not_printed: bool = True,
+        compile_obsolete: bool = False,
+    ):
         """
         :arg cache_running:
             Always cache running datastore data which makes mainly repeated retrieval of
@@ -48,6 +53,9 @@ class SysrepoConnection:
         ctx_flags = 0
         if not_printed:
             ctx_flags |= lib.SR_CTX_NO_PRINTED
+
+        if compile_obsolete:
+            ctx_flags |= lib.SR_CTX_COMPILE_OBSOLETE
 
         # mandatory flag to work with libyang-python
         ctx_flags |= lib.SR_CTX_SET_PRIV_PARSED

--- a/tests/test_connection.py
+++ b/tests/test_connection.py
@@ -93,3 +93,9 @@ class ConnectionTest(unittest.TestCase):
             sess = conn.start_session()
             self.assertEqual(sess.get_datastore(), "running")
             sess.stop()
+
+    def test_conn_start_session_compile_obsolete(self):
+        with sysrepo.SysrepoConnection(compile_obsolete=True) as conn:
+            sess = conn.start_session()
+            self.assertEqual(sess.get_datastore(), "running")
+            sess.stop()


### PR DESCRIPTION
Since version 4 of sysrepo and libyang, obsolete nodes are no longer compiled by default.
The sysrepo commit in the link makes sysrepo compile obsolete nodes. Add the compile_obsolete option, so that sysrepo can create a libyang context with the obsolete nodes.

Link: https://github.com/sysrepo/sysrepo/commit/15b757ab02cee5d6ae041983c46e302edfdec237